### PR TITLE
fix ‘strncpy’ is not a member of ‘std’

### DIFF
--- a/Server/Src/ServerEngine/CommonConvert.cpp
+++ b/Server/Src/ServerEngine/CommonConvert.cpp
@@ -612,7 +612,7 @@ BOOL CommonConvert::StrCopy(char* pszDest, const char* pszSrc, INT32 nLen)
 		return FALSE;
 	}
 
-	std::strncpy(pszDest, pszSrc, nLen - 1);
+	strncpy(pszDest, pszSrc, nLen - 1);
 
 	if (strlen(pszSrc) >= nLen)
 	{


### PR DESCRIPTION
Fix following error

```text
CommonConvert.cpp: In function ‘BOOL CommonConvert::StrCopy(char*, const char*, INT32)’:
CommonConvert.cpp:615:7: error: ‘strncpy’ is not a member of ‘std’; did you mean ‘strncpy’?
  615 |  std::strncpy(pszDest, pszSrc, nLen - 1);
      |       ^~~~~~~
In file included from Platform.h:37,
                 from stdafx.h:22,
                 from CommonConvert.cpp:1:
/usr/include/string.h:128:14: note: ‘strncpy’ declared here
  128 | extern char *strncpy (char *__restrict __dest,
      |              ^~~~~~~
make: *** [makefile:42: CommonConvert.o] Error 1
make: *** Waiting for unfinished jobs....
```